### PR TITLE
Fix README duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,7 @@ pip install -e .
 Run the script with a company CIK (Central Index Key):
 
 ```bash
-
 python scripts/fetch_10k.py <CIK>
-=======
-python edgar_fetcher.py <CIK>
-
 ```
 
 The latest 10‑K document will be saved in the `10k/` directory. Replace `<CIK>` with a valid CIK number (e.g., Apple Inc. is `0000320193`).
@@ -56,12 +52,7 @@ The latest 10‑K document will be saved in the `10k/` directory. Replace `<CIK>
 To list the files available in the latest 10‑K filing:
 
 ```bash
-
-
 python scripts/list_files.py <CIK>
-=======
-python edgar_files.py <CIK>
-
 ```
 This prints each file name along with its description, form type, and size.
 
@@ -70,10 +61,7 @@ Use `--json-out <path>` to write the list to a JSON file instead of printing it.
 To download a list of all company CIKs and names:
 
 ```bash
-
 python scripts/companies.py > companies.txt
-=======
-python edgar_companies.py > companies.txt
 ```
 
 The script outputs each CIK and company name on a single line, which can be
@@ -82,10 +70,7 @@ redirected to a file for later reference.
 ## Example
 
 ```bash
-
 python scripts/fetch_10k.py 0000320193
-=======
-python edgar_fetcher.py 0000320193
 ```
 
 This command downloads the most recent 10‑K for Apple and stores it locally.
@@ -143,12 +128,3 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
  /     \
 JoshuaKent
 ```
-=======
-Use `edgar_monitor.py` to check for new filings and upload their documents to an S3 bucket.
-
-```bash
-python edgar_monitor.py <CIK> [<CIK> ...] --bucket <bucket-name> [--prefix path/] [--state state.json]
-```
-
-The script keeps track of processed accession numbers in the specified state file and uploads each document from new filings to the given S3 bucket.
-Downloads run concurrently and a single progress bar shows overall progress across all documents while displaying the most recently handled file name.


### PR DESCRIPTION
### **User description**
## Summary
- remove stray `=======` lines
- drop old examples
- keep only CLI references using the `scripts/*` tools
- simplify monitoring section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a95d26ffc832ead1af545aed01ba8


___

### **PR Type**
Documentation


___

### **Description**
- Remove duplicate command examples and merge conflicts

- Clean up README formatting and structure

- Drop outdated monitoring section references

- Standardize script references to `scripts/*` tools


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clean documentation and remove duplicates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Remove stray <code>=======</code> merge conflict markers<br> <li> Delete duplicate command examples with old script names<br> <li> Clean up extra whitespace and formatting<br> <li> Remove outdated monitoring section at end


</details>


  </td>
  <td><a href="https://github.com/JoshuaKento/GPT-Trade/pull/3/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+0/-24</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>