### PR TITLE
Fix repository scan issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+# Repository Instructions For Codex
+
+## Project Overview
+
+This repository is `GPT-Trade`, published as `edgar-tools`: a Python toolkit for
+SEC EDGAR filing collection, parsing, monitoring, S3 upload, and database-backed
+ETL workflows.
+
+Use the refactored EDGAR architecture for new work. The original modules and
+scripts remain for compatibility, but `*_new.py` scripts and the newer classes
+under `edgar/` are the preferred path.
+
+Primary capabilities:
+
+- Fetch and list SEC filings such as 10-K, 10-Q, and 8-K.
+- Validate CIKs, accession numbers, SEC URLs, and configuration.
+- Parse filing documents and manage local processing state.
+- Upload filing artifacts to S3 when configured.
+- Run GPT-Trader ETL workflows with SQLAlchemy-backed persistence.
+- Monitor jobs, progress, performance, and SLA-style processing metrics.
+
+## Architecture
+
+- `edgar/`: core EDGAR toolkit. Prefer `client_new.py`, `s3_manager.py`,
+  `filing_processor.py`, `config_manager.py`, `urls.py`, `parser.py`, and
+  `state.py` for new work.
+- `gpt_trader/`: database-backed ETL platform, configuration, models,
+  monitoring, and filing processors.
+- `orchestration/`: scheduling, resource management, progress, performance, and
+  higher-level orchestration helpers.
+- `scripts/`: command-line entry points. Prefer `fetch_10k_new.py`,
+  `list_files_new.py`, `monitor_new.py`, and `gpt_trader_cli.py`.
+- `database/`: SQL schema, SQLAlchemy models, Alembic config, and migrations.
+- `config/` and `scripts/config/`: checked-in example or local JSON
+  configuration references.
+- `tests/`: pytest suite with unit, integration, parser, ETL, database, and
+  refactored-component coverage.
+- `CLAUDEmd/`: migration and cleanup notes for the refactored architecture.
+
+Do not introduce a `src/` layout for this project. Keep package code in the
+existing top-level packages unless a separate migration is explicitly requested.
+
+## Commands
+
+Setup:
+
+```bash
+python -m venv venv
+venv\Scripts\activate
+pip install -e ".[dev,test]"
+```
+
+Alternative dependency install:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+Common development commands:
+
+```bash
+make test
+make test-fast
+make test-unit
+make test-integration
+make test-cov
+make lint
+make format-check
+make type-check
+make security
+make pre-commit
+make qa
+```
+
+Direct pytest commands:
+
+```bash
+python -m pytest tests/ -v
+python -m pytest tests/test_refactored_components.py -v
+python -m pytest tests/test_parser.py -v
+python run_tests.py --type fast --no-coverage
+```
+
+Useful CLI commands:
+
+```bash
+python scripts/fetch_10k_new.py 0000320193 --verbose
+python scripts/list_files_new.py 0000320193 --json --output files.json
+python scripts/monitor_new.py 0000320193 --bucket my-bucket --dry-run
+python scripts/gpt_trader_cli.py init-db
+python scripts/gpt_trader_cli.py config create-sample
+python scripts/gpt_trader_cli.py run-etl --ticker AAPL
+```
+
+Some Makefile targets use Unix-style shell commands. On Windows, prefer the
+direct Python commands when a Make target is not available in the current shell.
+
+## Configuration
+
+Set a compliant SEC user agent before making SEC requests:
+
+```bash
+set SEC_USER_AGENT=YourApp (contact@example.com)
+```
+
+Common EDGAR settings:
+
+- `SEC_USER_AGENT`: required for SEC access.
+- `EDGAR_RATE_LIMIT`: default request rate limit, commonly `6.0`.
+- `EDGAR_TIMEOUT`, `EDGAR_MAX_RETRIES`, `EDGAR_NUM_WORKERS`.
+- `EDGAR_FORM_TYPES`, for example `10-K,10-Q`.
+- `EDGAR_S3_REGION`, `EDGAR_S3_PREFIX`, and AWS credentials for S3 workflows.
+- `EDGAR_LOG_LEVEL`.
+
+GPT-Trader/database settings commonly include:
+
+- `DATABASE_URL` for PostgreSQL or SQLite.
+- `S3_BUCKET` for upload workflows.
+- JSON config files created or referenced by `scripts/gpt_trader_cli.py`.
+
+Keep real credentials, private bucket names, production database URLs, `.env`
+files, downloaded filings, generated reports, logs, local databases, coverage
+outputs, and build artifacts out of commits unless the user explicitly asks for
+a tracked fixture or example. Prefer small synthetic fixtures in `tests/`.
+
+## Testing
+
+- Add or update tests when changing parsing, validation, configuration,
+  database, ETL, S3, orchestration, or CLI behavior.
+- Use mocked SEC, S3, and database dependencies unless an integration test is
+  explicitly required.
+- Keep tests deterministic and avoid live network access in default test runs.
+- Respect existing pytest markers: `unit`, `integration`, `slow`, and `network`.
+- Coverage is configured primarily for `edgar`; do not assume GPT-Trader changes
+  are covered unless targeted tests are added.
+
+## Workflow Cautions
+
+- Preserve SEC compliance: require a meaningful user agent, respect rate limits,
+  and avoid unnecessary live SEC traffic.
+- Prefer dependency injection, explicit configuration, context managers, and
+  resource cleanup over hidden global state.
+- Do not add live trading, broker execution, account access, or financial advice
+  behavior unless the user explicitly scopes that work.
+- Do not store secrets, AWS credentials, real account data, or private
+  production settings in the repository.
+- Keep legacy compatibility unless the user explicitly asks to remove it.
+- Keep changes focused and avoid broad cleanup unrelated to the task.
+- Do not create commits, tags, pushes, releases, or pull requests unless the user
+  explicitly requests them.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A comprehensive Python toolkit for downloading and monitoring SEC EDGAR filings with modern architecture, enhanced error handling, and production-ready features.
 
-## ✨ Features
+## Features
 
-- **🏗️ Modern Architecture**: Dependency injection, type safety, and modular design
-- **⚡ High Performance**: Connection pooling, async processing, and resource management
-- **🛡️ Robust Error Handling**: Comprehensive validation and specific exception types
-- **🔄 Real-time Monitoring**: Track new filings with S3 upload and manifest management
-- **📊 Multiple Output Formats**: JSON, CSV, and table outputs for filing data
-- **🧪 Production Ready**: Comprehensive testing and enterprise-grade reliability
+- **Modern Architecture**: Dependency injection, type safety, and modular design
+- **High Performance**: Connection pooling, async processing, and resource management
+- **Robust Error Handling**: Comprehensive validation and specific exception types
+- **Real-time Monitoring**: Track new filings with S3 upload and manifest management
+- **Multiple Output Formats**: JSON, CSV, and table outputs for filing data
+- **Production Ready**: Comprehensive testing and enterprise-grade reliability
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Installation
 
@@ -36,7 +36,7 @@ python scripts/list_files_new.py 0000320193 --json --output files.json
 python scripts/monitor_new.py 0000320193 --bucket my-bucket --async
 ```
 
-## 📋 Requirements
+## Requirements
 
 - **Python 3.11+** (managed via pyenv with `.python-version` file)
 - **Core Dependencies**: `requests`, `beautifulsoup4`, `boto3`, `aiohttp`, `tqdm`
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 
 For detailed setup instructions, see [PYENV_SETUP.md](PYENV_SETUP.md).
 
-## 🎯 Enhanced Scripts (Recommended)
+## Enhanced Scripts (Recommended)
 
 ### fetch_10k_new.py - Enhanced 10-K Fetcher
 ```bash
@@ -100,7 +100,7 @@ python scripts/monitor_new.py 0000320193 0000789019 --bucket my-bucket \
   --config config.json --async
 ```
 
-## 📦 Package Usage (New Architecture)
+## Package Usage (New Architecture)
 
 ### Basic Example
 ```python
@@ -153,7 +153,7 @@ manager = ConfigManager()
 config = manager.load_config("config.json")
 ```
 
-## ⚙️ Configuration
+## Configuration
 
 ### Environment Variables
 ```bash
@@ -187,7 +187,7 @@ export EDGAR_LOG_LEVEL=INFO
 }
 ```
 
-## 🧪 Testing
+## Testing
 
 ```bash
 # Run all tests
@@ -200,24 +200,24 @@ python -m pytest tests/test_refactored_components.py -v
 python -m pytest tests/test_refactored_components.py::TestURLValidation -v
 ```
 
-## 🏢 Enterprise Features
+## Enterprise Features
 
-- **🔒 Type Safety**: Complete type annotations prevent runtime errors
-- **🔄 Connection Pooling**: HTTP and S3 connections are reused for performance
-- **📊 Async Processing**: Handle multiple filings concurrently with proper backpressure
-- **🛡️ Comprehensive Validation**: CIK, accession numbers, and documents are validated
-- **📈 Resource Management**: Automatic cleanup prevents memory leaks
-- **🔍 Detailed Logging**: Structured logging with configurable levels
-- **⚡ Retry Logic**: Automatic retry with exponential backoff for network issues
+- **Type Safety**: Complete type annotations prevent runtime errors
+- **Connection Pooling**: HTTP and S3 connections are reused for performance
+- **Async Processing**: Handle multiple filings concurrently with proper backpressure
+- **Comprehensive Validation**: CIK, accession numbers, and documents are validated
+- **Resource Management**: Automatic cleanup prevents memory leaks
+- **Detailed Logging**: Structured logging with configurable levels
+- **Retry Logic**: Automatic retry with exponential backoff for network issues
 
-## 📚 Documentation
+## Documentation
 
 - **[CLAUDE.md](CLAUDE.md)** - Development guidance and architecture overview
 - **[MIGRATION.md](MIGRATION.md)** - Migration guide from legacy architecture  
 - **[Issues.md](Issues.md)** - Detailed analysis of improvements implemented
 - **[FINAL_MIGRATION_REPORT.md](FINAL_MIGRATION_REPORT.md)** - Complete migration summary
 
-## 🔄 Legacy Compatibility
+## Legacy Compatibility
 
 Legacy scripts remain available with deprecation warnings:
 ```bash
@@ -232,13 +232,13 @@ Legacy package functions are preserved:
 from edgar import cik_to_10digit, fetch_latest_10k, list_recent_filings
 ```
 
-## 🚨 SEC Compliance
+## SEC Compliance
 
 - **Rate Limiting**: Automatic throttling to SEC guidelines (6 requests/second default)
 - **User-Agent**: Required contact email in User-Agent header
 - **Respectful Access**: Built-in delays and retry logic to avoid overwhelming SEC servers
 
-## 📝 Examples
+## Examples
 
 ### Monitor Multiple Companies
 ```bash
@@ -270,14 +270,14 @@ with EdgarClient(config) as client:
             print(f"Error processing {cik}: {e}")
 ```
 
-## 🤝 Contributing
+## Contributing
 
 1. **Setup**: Follow the installation instructions above
 2. **Testing**: Ensure all tests pass with `python -m pytest tests/ -v`
 3. **Code Quality**: Use the new architecture classes for consistency
 4. **Documentation**: Update relevant documentation for changes
 
-## 📄 License
+## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 

--- a/README_GPT_TRADER.md
+++ b/README_GPT_TRADER.md
@@ -2,7 +2,7 @@
 
 A comprehensive platform for collecting, storing, and analyzing SEC EDGAR filings with advanced ETL capabilities, database persistence, and performance monitoring.
 
-## 🚀 Features
+## Features
 
 ### Phase 2 - Database & ETL Platform (v0.1)
 
@@ -22,7 +22,7 @@ A comprehensive platform for collecting, storing, and analyzing SEC EDGAR filing
 - **Progress Tracking**: Real-time monitoring and status reporting
 - **Error Recovery**: Automatic retry mechanisms and failure handling
 
-## 📋 Requirements
+## Requirements
 
 - Python 3.9+
 - PostgreSQL 12+ (or SQLite for development)
@@ -30,7 +30,7 @@ A comprehensive platform for collecting, storing, and analyzing SEC EDGAR filing
 - 2GB+ RAM for processing 50 tickers
 - Valid email for SEC user-agent compliance
 
-## 🛠 Installation
+## Installation
 
 ### 1. Clone Repository
 ```bash
@@ -60,7 +60,7 @@ export S3_BUCKET="your-s3-bucket"
 python scripts/gpt_trader_cli.py init-db
 ```
 
-## ⚙️ Configuration
+## Configuration
 
 ### Create Configuration File
 ```bash
@@ -106,7 +106,7 @@ python scripts/gpt_trader_cli.py add-ticker NVDA 0000320193 --priority 1
 python scripts/gpt_trader_cli.py add-ticker TSLA 0001318605 --priority 2
 ```
 
-## 🚀 Quick Start
+## Quick Start
 
 ### 1. Initialize System
 ```bash
@@ -150,7 +150,7 @@ python scripts/gpt_trader_cli.py monitor
 python scripts/gpt_trader_cli.py start-scheduler
 ```
 
-## 📊 Usage Examples
+## Usage Examples
 
 ### Programmatic Usage
 
@@ -208,7 +208,7 @@ with session_scope() as session:
     print(f"{pending_count} filings pending processing")
 ```
 
-## 🔧 CLI Reference
+## CLI Reference
 
 ### Database Commands
 ```bash
@@ -237,11 +237,11 @@ gpt_trader_cli.py job-status JOB_ID           # Job details
 gpt_trader_cli.py monitor [--refresh SECONDS] # Monitoring dashboard
 ```
 
-## 📈 Performance & SLA
+## Performance & SLA
 
 ### Default SLA Targets
-- **Processing Time**: ≤ 30 minutes for 50 tickers
-- **Success Rate**: ≥ 95% of filings processed successfully
+- **Processing Time**: <= 30 minutes for 50 tickers
+- **Success Rate**: >= 95% of filings processed successfully
 - **Memory Usage**: < 2GB peak usage
 - **Error Rate**: < 10% failure rate
 
@@ -259,7 +259,7 @@ gpt_trader_cli.py monitor [--refresh SECONDS] # Monitoring dashboard
 - Database connection health
 - S3 upload success rates
 
-## 🔐 Security Features
+## Security Features
 
 - **Input Validation**: Comprehensive path traversal protection
 - **Credential Management**: Secure AWS credential handling
@@ -267,7 +267,7 @@ gpt_trader_cli.py monitor [--refresh SECONDS] # Monitoring dashboard
 - **Error Handling**: Secure error messages without data leakage
 - **Dependency Security**: Pinned versions with security scanning
 
-## 🧪 Testing
+## Testing
 
 ### Run Tests
 ```bash
@@ -288,27 +288,27 @@ pytest --cov=gpt_trader --cov-report=html
 - Performance and SLA compliance tests
 - Integration tests with test containers
 
-## 📁 Project Structure
+## Project Structure
 
 ```
 gpt_trader/
-├── __init__.py              # Main package exports
-├── models.py                # SQLAlchemy database models
-├── database.py              # Database connection management
-├── config.py                # Configuration management
-├── filing_processor_db.py   # Database-enabled filing processor
-├── etl.py                  # ETL pipeline orchestration
-└── monitoring.py           # Performance monitoring & SLA
+|-- __init__.py              # Main package exports
+|-- models.py                # SQLAlchemy database models
+|-- database.py              # Database connection management
+|-- config.py                # Configuration management
+|-- filing_processor_db.py   # Database-enabled filing processor
+|-- etl.py                   # ETL pipeline orchestration
+`-- monitoring.py            # Performance monitoring & SLA
 
 scripts/
-└── gpt_trader_cli.py       # Command-line interface
+`-- gpt_trader_cli.py        # Command-line interface
 
 tests/
-├── test_gpt_trader_models.py # Database model tests
-└── test_gpt_trader_etl.py    # ETL pipeline tests
+|-- test_gpt_trader_models.py # Database model tests
+`-- test_gpt_trader_etl.py    # ETL pipeline tests
 ```
 
-## 🚀 Future Roadmap
+## Future Roadmap
 
 ### Phase 3 - Analytics & RAG (Month 3)
 - Vector embeddings with pgvector
@@ -322,7 +322,7 @@ tests/
 - Portfolio optimization
 - Live trading API connections
 
-## 🤝 Contributing
+## Contributing
 
 1. Fork the repository
 2. Create feature branch (`git checkout -b feature/amazing-feature`)
@@ -331,16 +331,16 @@ tests/
 5. Push to branch (`git push origin feature/amazing-feature`)
 6. Open Pull Request
 
-## 📝 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 📧 Support
+## Support
 
 - **Issues**: [GitHub Issues](https://github.com/JoshuaKento/GPT-Trade/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/JoshuaKento/GPT-Trade/discussions)
 - **Email**: support@gpt-trader.com
 
-## ⚠️ Disclaimer
+## Disclaimer
 
 This software is for educational and research purposes only. Not financial advice. Always comply with SEC regulations and respect API rate limits.

--- a/edgar/client_new.py
+++ b/edgar/client_new.py
@@ -16,35 +16,34 @@ class OptimizedHTTPAdapter(HTTPAdapter):
     """HTTP adapter with optimized connection pooling and keep-alive settings."""
 
     def __init__(self, config: "ClientConfig", *args, **kwargs):
-        self.config = config
+        self._client_config = config
         super().__init__(*args, **kwargs)
 
-    def init_poolmanager(self, *args, **kwargs):
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
         """Initialize pool manager with optimized settings."""
-        kwargs.update(
-            {
-                "num_pools": self.config.pool_connections,
-                "maxsize": self.config.pool_maxsize,
-                "block": False,
-            }
-        )
+        config = self._client_config
 
-        if self.config.socket_options:
+        if config.socket_options:
             # Enable TCP keep-alive
             import socket
 
-            kwargs["socket_options"] = [
+            pool_kwargs["socket_options"] = [
                 (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
                 (
                     socket.IPPROTO_TCP,
                     socket.TCP_KEEPIDLE,
-                    self.config.keepalive_timeout,
+                    config.keepalive_timeout,
                 ),
                 (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10),
                 (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 6),
             ]
 
-        return super().init_poolmanager(*args, **kwargs)
+        return super().init_poolmanager(
+            config.pool_connections,
+            config.pool_maxsize,
+            block=False,
+            **pool_kwargs,
+        )
 
 
 class SyncAdaptiveRateLimiter:

--- a/gpt_trader/__init__.py
+++ b/gpt_trader/__init__.py
@@ -12,8 +12,10 @@ from .database import DatabaseManager, get_session
 from .models import Company, Filing, Document, ProcessingJob
 from .etl import ETLPipeline
 from .config import GPTTraderConfig
+from .filing_processor_db import BatchFilingProcessor
 
 __all__ = [
+    "BatchFilingProcessor",
     "DatabaseManager",
     "get_session", 
     "Company",

--- a/orchestration/__init__.py
+++ b/orchestration/__init__.py
@@ -12,7 +12,6 @@ Core Components:
     - PerformanceMonitor: SLA compliance and performance tracking
     - ResourceManager: Rate limiting and resource throttling
     - CLIRunner: Command-line interface for job execution
-    - Dashboard: Web-based monitoring interface
 
 Key Features:
     - Process 50 tickers within 30 minutes SLA
@@ -24,47 +23,44 @@ Key Features:
     - Resource throttling and backpressure
 """
 
-from .orchestrator import OrchestrationManager, OrchestrationConfig
-from .scheduler import JobScheduler, JobConfig, JobStatus, ScheduleType
-from .progress import ProgressTracker, JobProgress, ProgressStatus
-from .performance import PerformanceMonitor, SLAMetrics, PerformanceReport
-from .resource_manager import ResourceManager, ResourceConfig, RateLimiter
-from .cli import CLIRunner, CLIConfig
-from .dashboard import DashboardService, DashboardConfig
+from importlib import import_module
+from typing import Any
 
 __version__ = "1.0.0"
 
-__all__ = [
-    # Core orchestration
-    "OrchestrationManager",
-    "OrchestrationConfig",
-    
-    # Job scheduling
-    "JobScheduler", 
-    "JobConfig",
-    "JobStatus",
-    "ScheduleType",
-    
-    # Progress tracking
-    "ProgressTracker",
-    "JobProgress", 
-    "ProgressStatus",
-    
-    # Performance monitoring
-    "PerformanceMonitor",
-    "SLAMetrics",
-    "PerformanceReport",
-    
-    # Resource management
-    "ResourceManager",
-    "ResourceConfig", 
-    "RateLimiter",
-    
-    # CLI interface
-    "CLIRunner",
-    "CLIConfig",
-    
-    # Dashboard
-    "DashboardService",
-    "DashboardConfig",
-]
+_EXPORTS = {
+    "OrchestrationManager": ".orchestrator",
+    "OrchestrationConfig": ".orchestrator",
+    "JobScheduler": ".scheduler",
+    "JobConfig": ".scheduler",
+    "JobStatus": ".scheduler",
+    "ScheduleType": ".scheduler",
+    "ProgressTracker": ".progress",
+    "JobProgress": ".progress",
+    "ProgressStatus": ".progress",
+    "PerformanceMonitor": ".performance",
+    "SLAMetrics": ".performance",
+    "PerformanceReport": ".performance",
+    "ResourceManager": ".resource_manager",
+    "ResourceConfig": ".resource_manager",
+    "RateLimiter": ".resource_manager",
+    "CLIRunner": ".cli",
+    "CLIConfig": ".cli",
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily load public exports from their implementation modules."""
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(_EXPORTS[name], __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted([*globals(), *_EXPORTS])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ companies = "scripts.companies:main"
 monitor-edgar = "scripts.monitor_new:main"
 
 [tool.setuptools.packages.find]
-include = ["edgar*", "scripts*"]
+include = ["edgar*", "gpt_trader*", "scripts*"]
 exclude = ["tests*", "CLAUDEmd*", "config*", "manifests*"]
 
 # Tool configurations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "aiohttp>=3.8.0",
     "tqdm>=4.64.0",
     "sqlalchemy>=2.0.0",
-    "alembic>=1.13.0"
+    "alembic>=1.13.0",
+    "psutil>=5.9.0"
 ]
 
 [project.optional-dependencies]

--- a/scripts/companies.py
+++ b/scripts/companies.py
@@ -1,15 +1,26 @@
 #!/usr/bin/env python3
 """CLI to list all companies with CIK codes."""
-import logging
+import argparse
 import os
 import sys
+from typing import Optional, Sequence
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from edgar.companies import fetch_cik_company_list
 from edgar.logging_config import setup_logging
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    return argparse.ArgumentParser(
+        description="List all SEC companies with CIK codes.",
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_parser()
+    parser.parse_args(argv)
+
     setup_logging()
     comps = fetch_cik_company_list()
     try:

--- a/scripts/gpt_trader_cli.py
+++ b/scripts/gpt_trader_cli.py
@@ -43,13 +43,13 @@ def cmd_init_db(args):
     
     try:
         initialize_database(drop_existing=args.reset)
-        print("✅ Database initialized successfully")
+        print("[OK] Database initialized successfully")
         
         if args.reset:
-            print("⚠️  Existing data was dropped")
+            print("[WARN] Existing data was dropped")
             
     except Exception as e:
-        print(f"❌ Failed to initialize database: {e}")
+        print(f"[ERROR] Failed to initialize database: {e}")
         sys.exit(1)
 
 
@@ -61,9 +61,9 @@ def cmd_db_status(args):
     try:
         # Health check
         if health_check():
-            print("✅ Database connection: HEALTHY")
+            print("[OK] Database connection: HEALTHY")
         else:
-            print("❌ Database connection: FAILED")
+            print("[ERROR] Database connection: FAILED")
             return
         
         # Connection info
@@ -91,11 +91,21 @@ def cmd_db_status(args):
             
             print(f"\nRecent Jobs ({len(recent_jobs)}):")
             for job in recent_jobs:
-                status_emoji = "✅" if job.status == ProcessingStatus.COMPLETED else "❌" if job.status == ProcessingStatus.FAILED else "⏳"
-                print(f"  {status_emoji} {job.job_name} ({job.status}) - {job.created_at.strftime('%Y-%m-%d %H:%M')}")
+                if job.status == ProcessingStatus.COMPLETED:
+                    status_label = "[OK]"
+                elif job.status == ProcessingStatus.FAILED:
+                    status_label = "[ERROR]"
+                else:
+                    status_label = "[PENDING]"
+
+                created_at = job.created_at.strftime('%Y-%m-%d %H:%M')
+                print(
+                    f"  {status_label} {job.job_name} "
+                    f"({job.status}) - {created_at}"
+                )
                 
     except Exception as e:
-        print(f"❌ Failed to get database status: {e}")
+        print(f"[ERROR] Failed to get database status: {e}")
         sys.exit(1)
 
 
@@ -110,7 +120,7 @@ def cmd_config_show(args):
         print(json.dumps(config.to_dict(), indent=2, default=str))
         
     except Exception as e:
-        print(f"❌ Failed to load configuration: {e}")
+        print(f"[ERROR] Failed to load configuration: {e}")
         sys.exit(1)
 
 
@@ -130,11 +140,11 @@ def cmd_config_create_sample(args):
         output_file = args.output or "gpt_trader_config.json"
         config.to_file(output_file)
         
-        print(f"✅ Sample configuration created: {output_file}")
-        print(f"📝 Added {len(config.tickers)} sample tickers")
+        print(f"[OK] Sample configuration created: {output_file}")
+        print(f"[INFO] Added {len(config.tickers)} sample tickers")
         
     except Exception as e:
-        print(f"❌ Failed to create sample configuration: {e}")
+        print(f"[ERROR] Failed to create sample configuration: {e}")
         sys.exit(1)
 
 
@@ -151,10 +161,10 @@ def cmd_add_ticker(args):
         # Save configuration
         config_manager.save_config()
         
-        print(f"✅ Added ticker {args.ticker} (CIK: {args.cik}) to configuration")
+        print(f"[OK] Added ticker {args.ticker} (CIK: {args.cik}) to configuration")
         
     except Exception as e:
-        print(f"❌ Failed to add ticker: {e}")
+        print(f"[ERROR] Failed to add ticker: {e}")
         sys.exit(1)
 
 
@@ -182,15 +192,15 @@ def cmd_sync_companies(args):
         for ticker_config in config.tickers:
             try:
                 company = processor.sync_company_from_ticker_config(ticker_config)
-                print(f"✅ Synced {ticker_config.ticker} -> Company ID {company.id}")
+                print(f"[OK] Synced {ticker_config.ticker} -> Company ID {company.id}")
                 synced_count += 1
             except Exception as e:
-                print(f"❌ Failed to sync {ticker_config.ticker}: {e}")
+                print(f"[ERROR] Failed to sync {ticker_config.ticker}: {e}")
         
-        print(f"✅ Synced {synced_count} companies to database")
+        print(f"[OK] Synced {synced_count} companies to database")
         
     except Exception as e:
-        print(f"❌ Failed to sync companies: {e}")
+        print(f"[ERROR] Failed to sync companies: {e}")
         sys.exit(1)
 
 
@@ -209,14 +219,14 @@ def cmd_run_etl(args):
             # Process specific ticker
             ticker_config = config.get_ticker_by_symbol(args.ticker)
             if not ticker_config:
-                print(f"❌ Ticker {args.ticker} not found in configuration")
+                print(f"[ERROR] Ticker {args.ticker} not found in configuration")
                 sys.exit(1)
             
             print(f"Processing ticker: {args.ticker}")
             new_filings, updated_filings = batch_processor.processor.fetch_and_store_filings(
                 ticker_config, max_filings=args.max_filings
             )
-            print(f"✅ Completed {args.ticker}: {new_filings} new, {updated_filings} updated filings")
+            print(f"[OK] Completed {args.ticker}: {new_filings} new, {updated_filings} updated filings")
             
         else:
             # Process all active tickers
@@ -224,13 +234,13 @@ def cmd_run_etl(args):
                 job_name=args.job_name or f"cli_etl_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
             )
             
-            print(f"✅ Batch ETL completed")
+            print("[OK] Batch ETL completed")
             print(f"Job ID: {job.id}")
             print(f"Status: {job.status}")
             print(f"Duration: {job.duration:.2f} seconds" if job.duration else "N/A")
             
     except Exception as e:
-        print(f"❌ ETL process failed: {e}")
+        print(f"[ERROR] ETL process failed: {e}")
         sys.exit(1)
 
 
@@ -245,7 +255,7 @@ def cmd_start_scheduler(args):
         scheduler = ETLScheduler(config)
         scheduler.start()
         
-        print("✅ ETL scheduler started")
+        print("[OK] ETL scheduler started")
         print("Press Ctrl+C to stop...")
         
         try:
@@ -253,12 +263,12 @@ def cmd_start_scheduler(args):
             while True:
                 time.sleep(1)
         except KeyboardInterrupt:
-            print("\n🛑 Stopping scheduler...")
+            print("\nStopping scheduler...")
             scheduler.stop()
-            print("✅ Scheduler stopped")
+            print("[OK] Scheduler stopped")
             
     except Exception as e:
-        print(f"❌ Failed to start scheduler: {e}")
+        print(f"[ERROR] Failed to start scheduler: {e}")
         sys.exit(1)
 
 
@@ -295,7 +305,7 @@ def cmd_list_jobs(args):
                 print(f"{job.id:<6} {job.job_name[:29]:<30} {job.status:<12} {duration_str:<10} {items_str:<8} {created_str:<16}")
                 
     except Exception as e:
-        print(f"❌ Failed to list jobs: {e}")
+        print(f"[ERROR] Failed to list jobs: {e}")
         sys.exit(1)
 
 
@@ -306,7 +316,7 @@ def cmd_job_status(args):
             job = session.query(ProcessingJob).filter(ProcessingJob.id == args.job_id).first()
             
             if not job:
-                print(f"❌ Job {args.job_id} not found")
+                print(f"[ERROR] Job {args.job_id} not found")
                 sys.exit(1)
             
             print(f"Job Details (ID: {job.id}):")
@@ -335,7 +345,7 @@ def cmd_job_status(args):
                 print(f"Parameters: {json.dumps(job.parameters, indent=2)}")
                 
     except Exception as e:
-        print(f"❌ Failed to get job status: {e}")
+        print(f"[ERROR] Failed to get job status: {e}")
         sys.exit(1)
 
 
@@ -377,8 +387,8 @@ def cmd_monitor(args):
                 
                 # SLA status
                 compliance = sla_status['compliance_status']
-                emoji = "✅" if compliance == "healthy" else "⚠️"
-                print(f"SLA Status: {emoji} {compliance.upper()} | "
+                status_label = "[OK]" if compliance == "healthy" else "[WARN]"
+                print(f"SLA Status: {status_label} {compliance.upper()} | "
                       f"Violations (24h): {sla_status['violations_24h']}")
                 
                 # Database status
@@ -391,23 +401,23 @@ def cmd_monitor(args):
                             ProcessingJob.status == ProcessingStatus.IN_PROGRESS
                         ).count()
                         
-                        print(f"Database: ✅ Connected | "
+                        print(f"Database: [OK] Connected | "
                               f"Pending Filings: {pending_filings} | "
                               f"Active Jobs: {active_jobs}")
                 else:
-                    print("Database: ❌ Disconnected")
+                    print("Database: [ERROR] Disconnected")
                 
                 print("-" * 80)
                 time.sleep(args.refresh or 5)
                 
         except KeyboardInterrupt:
-            print("\n🛑 Stopping monitoring...")
+            print("\nStopping monitoring...")
             performance_monitor.stop()
             sla_monitor.stop()
-            print("✅ Monitoring stopped")
+            print("[OK] Monitoring stopped")
             
     except Exception as e:
-        print(f"❌ Failed to start monitoring: {e}")
+        print(f"[ERROR] Failed to start monitoring: {e}")
         sys.exit(1)
 
 
@@ -511,7 +521,7 @@ Examples:
     if handler:
         handler(args)
     else:
-        print(f"❌ Unknown command: {args.command}")
+        print(f"[ERROR] Unknown command: {args.command}")
         sys.exit(1)
 
 

--- a/tests/test_database_integration.py
+++ b/tests/test_database_integration.py
@@ -9,12 +9,15 @@ import uuid
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any, Dict, Generator, List, Optional
 
-import asyncpg
 import pytest
-from moto import mock_s3
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
+
+try:
+    import asyncpg
+except ModuleNotFoundError:
+    asyncpg = None
 
 from tests.test_database_models import (
     CompanyFactory,
@@ -212,6 +215,9 @@ def test_db():
 @pytest.fixture
 def postgres_test_db():
     """Provide PostgreSQL test database container."""
+    if asyncpg is None:
+        pytest.skip("asyncpg is required for PostgreSQL integration tests")
+
     container = DatabaseTestContainer(use_real_postgres=True)
     with container.get_test_database():
         yield container

--- a/tests/test_e2e_workflow.py
+++ b/tests/test_e2e_workflow.py
@@ -11,7 +11,10 @@ from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 import boto3
-from moto import mock_s3
+try:
+    from moto import mock_s3
+except ImportError:
+    from moto import mock_aws as mock_s3
 
 from tests.test_database_models import (
     CompanyFactory,

--- a/tests/test_etl_pipeline.py
+++ b/tests/test_etl_pipeline.py
@@ -10,7 +10,10 @@ from unittest.mock import AsyncMock, Mock, patch, MagicMock, call
 import aiohttp
 import pytest
 import responses
-from moto import mock_s3
+try:
+    from moto import mock_s3
+except ImportError:
+    from moto import mock_aws as mock_s3
 import boto3
 
 from tests.test_database_models import (

--- a/tests/test_gpt_trader_public_imports.py
+++ b/tests/test_gpt_trader_public_imports.py
@@ -1,0 +1,8 @@
+"""Regression tests for documented gpt_trader public imports."""
+
+
+def test_documented_batch_filing_processor_public_import():
+    from gpt_trader import BatchFilingProcessor
+    from gpt_trader.filing_processor_db import BatchFilingProcessor as expected
+
+    assert BatchFilingProcessor is expected

--- a/tests/test_orchestration_import.py
+++ b/tests/test_orchestration_import.py
@@ -1,0 +1,35 @@
+"""Regression tests for orchestration package import entry points."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_python(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run Python from the repository root."""
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_orchestration_package_imports() -> None:
+    result = run_python("-c", "import orchestration")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+
+def test_orchestration_cli_help_reaches_parser() -> None:
+    result = run_python("-m", "orchestration.cli", "--help")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert "usage:" in result.stdout.lower()
+    assert "ETL Pipeline Orchestration CLI" in result.stdout

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -2,10 +2,9 @@
 
 import asyncio
 import concurrent.futures
-import memory_profiler
 import psutil
 import time
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import Mock, patch
@@ -119,8 +118,8 @@ class PerformanceMetrics:
                     assert actual <= threshold, f"Latency {actual:.3f}s exceeds SLA {threshold}s"
 
 
-@contextmanager
-def performance_monitor():
+@asynccontextmanager
+async def performance_monitor():
     """Context manager for performance monitoring."""
     metrics = PerformanceMetrics()
     metrics.start_monitoring()
@@ -255,7 +254,7 @@ class TestSLACompliance:
     @pytest.mark.asyncio
     async def test_single_ticker_processing_time(self, performance_edgar_api):
         """Test single ticker processing meets SLA."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             ciks = ["0000320000"]  # Single company
@@ -280,7 +279,7 @@ class TestSLACompliance:
     @pytest.mark.asyncio
     async def test_fifty_tickers_sla_compliance(self, performance_edgar_api):
         """Test 50 tickers processing meets 30-minute SLA."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # All 50 companies
@@ -319,7 +318,7 @@ class TestSLACompliance:
         
         # Test with increasing data volumes
         for num_companies in [1, 5, 10, 25]:
-            with performance_monitor() as metrics:
+            async with performance_monitor() as metrics:
                 pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
                 
                 ciks = [f"000032{i:04d}" for i in range(num_companies)]
@@ -470,7 +469,7 @@ class TestThroughputRequirements:
     @pytest.mark.asyncio
     async def test_filing_discovery_throughput(self, performance_edgar_api):
         """Test filing discovery throughput."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # Large batch for throughput testing
@@ -494,7 +493,7 @@ class TestThroughputRequirements:
     @pytest.mark.asyncio
     async def test_document_download_throughput(self, performance_edgar_api):
         """Test document download throughput."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # Test downloading multiple filings
@@ -525,7 +524,7 @@ class TestStressAndLoad:
     @pytest.mark.asyncio
     async def test_high_concurrency_stress(self, performance_edgar_api):
         """Test pipeline under high concurrency load."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # High concurrency test
@@ -556,7 +555,7 @@ class TestStressAndLoad:
     @pytest.mark.asyncio
     async def test_sustained_load(self, performance_edgar_api):
         """Test pipeline under sustained load."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # Simulate sustained load for multiple batches
@@ -592,7 +591,7 @@ class TestResourceUtilization:
     @pytest.mark.asyncio
     async def test_cpu_utilization_efficiency(self, performance_edgar_api):
         """Test CPU utilization during processing."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # CPU-intensive task simulation
@@ -613,7 +612,7 @@ class TestResourceUtilization:
     @pytest.mark.asyncio
     async def test_memory_efficiency(self, performance_edgar_api):
         """Test memory usage efficiency."""
-        with performance_monitor() as metrics:
+        async with performance_monitor() as metrics:
             pipeline = PerformanceETLPipeline(performance_edgar_api, metrics)
             
             # Process data that should fit efficiently in memory


### PR DESCRIPTION
## Summary
- Replace stale strata-trader AGENTS guidance with GPT-Trade / EDGAR Tools instructions.
- Fix orchestration package imports by removing the missing dashboard export path and adding regression coverage.
- Restore pytest collection by handling optional asyncpg, Moto mock changes, and async performance test syntax.
- Align documented gpt_trader public imports and package discovery for BatchFilingProcessor.
- Clean mojibake from primary docs/CLI output and make companies.py --help side-effect free.
- Fix the Edgar HTTP adapter config attribute collision found during validation.

## Validation
- `git diff --cached --check`: passed
- `python -m pytest tests\test_refactored_components.py tests\test_orchestration_import.py tests\test_gpt_trader_public_imports.py tests\test_companies.py -q --no-cov`: passed, 37 passed
- `python -m pytest --collect-only -q`: passed, 240 tests collected
- `python -m pytest tests -q --no-cov`: failed due to existing broad suite failures outside this cleanup scope, including SQLite temp-file locking on Windows, Moto/xunit setup_method mismatch, missing SEC_USER_AGENT in GPT Trader fixtures, and performance threshold failures

## Limitations
- This PR restores collection and targeted regressions, but does not make the entire existing suite pass.
- Unknown pytest markers such as `e2e` and `performance` still emit warnings.

Closes #8
Closes #9
Closes #10
Closes #11
Closes #12